### PR TITLE
Add AI class creation and selection system

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -133,6 +133,32 @@ app.post('/location', async (req, res) => {
   }
 });
 
+app.post('/class', async (req, res) => {
+  const { seed } = req.body || {};
+  const base =
+    'Generate a fantasy RPG character class in the format "NAME: <name>; DESCRIPTION: <description>".';
+  const prompt = seed ? `${base} Seed: ${seed}` : base;
+  try {
+    const j = await callAI(prompt);
+    const text = j[0]?.generated_text || '';
+    const match = text.match(/NAME:\s*(.*);\s*DESCRIPTION:\s*([^\n]+)/i);
+    if (match) {
+      return res.json({ name: match[1].trim(), description: match[2].trim() });
+    }
+    throw new Error('parse');
+  } catch {
+    const names = ['Warrior', 'Mage', 'Rogue', 'Cleric'];
+    const descs = [
+      'A master of melee combat.',
+      'A wielder of arcane magic.',
+      'A stealthy trickster.',
+      'A holy healer.',
+    ];
+    const i = Math.floor(Math.random() * names.length);
+    res.json({ name: names[i], description: descs[i] });
+  }
+});
+
 app.post('/item', async (req, res) => {
   const { seed } = req.body || {};
   const base =

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import Authentication from './Pages/Authentication/Authentication';
 import User from './Pages/UserPage/User.jsx';
 import Stats from './Pages/StatPage/Stats.jsx';
 import Game from './Pages/GamePage/Game.jsx';
+import Classes from './Pages/ClassPage/Classes.jsx';
 
 function App() {
   return (
@@ -19,6 +20,7 @@ function App() {
           <Route path="/Authentication" element={<Authentication/>}/>
           <Route path="/User" element={<User/>}/>
           <Route path="/Stats" element={<Stats/>}/>
+          <Route path="/Classes" element={<Classes/>}/>
           <Route path="/Game" element={<Game/>}/>
         </Routes>
       </BrowserRouter>

--- a/src/Pages/ClassPage/Classes.jsx
+++ b/src/Pages/ClassPage/Classes.jsx
@@ -1,0 +1,94 @@
+import React, { useState, useEffect } from 'react';
+import { Paper, TextInput, Textarea, Button, Stack, Title, List, Text } from '@mantine/core';
+
+const defaultStats = {
+  health: 100,
+  level: 1,
+  xp: 0,
+  items: [],
+  skills: [],
+  abilities: [],
+  places: [],
+  people: [],
+  class: '',
+};
+
+const defaultClass = { name: '', description: '' };
+
+const Classes = () => {
+  const [classes, setClasses] = useState(() => {
+    const saved = localStorage.getItem('worldClasses');
+    if (saved) {
+      try { return JSON.parse(saved); } catch {}
+    }
+    return [];
+  });
+  const [form, setForm] = useState(defaultClass);
+  const [currentClass, setCurrentClass] = useState('');
+
+  useEffect(() => {
+    const savedStats = localStorage.getItem('playerStats');
+    if (savedStats) {
+      try {
+        const s = JSON.parse(savedStats);
+        if (s.class) setCurrentClass(s.class);
+      } catch {}
+    }
+  }, []);
+
+  const saveClasses = (cls) => {
+    setClasses(cls);
+    localStorage.setItem('worldClasses', JSON.stringify(cls));
+  };
+
+  const handleAdd = () => {
+    if (!form.name) return;
+    saveClasses([...classes, form]);
+    setForm(defaultClass);
+  };
+
+  const handleGenerate = () => {
+    fetch('/class', { method: 'POST', headers: { 'Content-Type': 'application/json' } })
+      .then((r) => (r.ok ? r.json() : Promise.reject()))
+      .then((d) => {
+        if (d.name && d.description) {
+          setForm({ name: d.name, description: d.description });
+        }
+      })
+      .catch(() => {});
+  };
+
+  const handleSelect = (cls) => {
+    let stats = { ...defaultStats };
+    const saved = localStorage.getItem('playerStats');
+    if (saved) {
+      try { stats = { ...stats, ...JSON.parse(saved) }; } catch {}
+    }
+    stats.class = cls.name;
+    localStorage.setItem('playerStats', JSON.stringify(stats));
+    setCurrentClass(cls.name);
+  };
+
+  return (
+    <Paper p="md" m="md" shadow="xs">
+      <Title order={2}>Classes</Title>
+      {currentClass && <Text>Current Class: {currentClass}</Text>}
+      <Stack>
+        <TextInput label="Class Name" value={form.name} onChange={(e) => setForm({ ...form, name: e.currentTarget.value })} />
+        <Textarea label="Description" value={form.description} onChange={(e) => setForm({ ...form, description: e.currentTarget.value })} />
+        <Button onClick={handleAdd}>Add Class</Button>
+        <Button variant="outline" onClick={handleGenerate}>Generate with AI</Button>
+      </Stack>
+      <Title order={3} mt="md">Available Classes</Title>
+      <List spacing="xs" withPadding>
+        {classes.map((c, idx) => (
+          <List.Item key={idx}>
+            <b>{c.name}</b>: {c.description} <Button size="xs" ml="sm" onClick={() => handleSelect(c)}>Select</Button>
+          </List.Item>
+        ))}
+      </List>
+    </Paper>
+  );
+};
+
+export default Classes;

--- a/src/Pages/GamePage/Game.jsx
+++ b/src/Pages/GamePage/Game.jsx
@@ -26,6 +26,7 @@ const defaultStats = {
   abilities: [],
   places: [],
   people: [],
+  class: '',
 };
 
 const Game = () => {
@@ -133,7 +134,7 @@ const Game = () => {
       const place = places[`${position.x},${position.y}`];
       addLog(`You look around. ${place.description}`);
     } else if (cmd === 'stats') {
-      addLog(`HP: ${stats.health} | Position: ${position.x}, ${position.y}`);
+      addLog(`HP: ${stats.health} | Class: ${stats.class || 'None'} | Position: ${position.x}, ${position.y}`);
     } else if (cmd === 'save') {
       localStorage.setItem('gameState', JSON.stringify({ position, log, places }));
       localStorage.setItem('playerStats', JSON.stringify(stats));

--- a/src/Pages/Navigation/Navigation.jsx
+++ b/src/Pages/Navigation/Navigation.jsx
@@ -25,6 +25,9 @@ const Navigation = () => {
                   <Button component={Link} to="/Stats" variant="gradient" compact gradient={{ from: 'red', to: 'orange', deg: 80 }}>
                     Stats
                   </Button>
+                  <Button component={Link} to="/Classes" variant="gradient" compact gradient={{ from: 'orange', to: 'red', deg: 85 }}>
+                    Classes
+                  </Button>
                   <Button component={Link} to="/Game" variant="gradient" compact gradient={{ from: 'orange', to: 'red', deg: 90 }}>
                     Game
                   </Button>

--- a/src/Pages/StatPage/Stats.jsx
+++ b/src/Pages/StatPage/Stats.jsx
@@ -10,6 +10,7 @@ const defaultStats = {
   abilities: [],
   places: [],
   people: [],
+  class: '',
 };
 
 const Stats = () => {
@@ -55,6 +56,7 @@ const Stats = () => {
       <Text>Health: {stats.health}</Text>
       <Text>Level: {stats.level}</Text>
       <Text>XP: {stats.xp}</Text>
+      <Text>Class: {stats.class || 'None'}</Text>
       <Title order={3} mt="sm">Items</Title>
       <List size="sm" withPadding>
         {stats.items.map((it, idx) => (


### PR DESCRIPTION
## Summary
- add `/class` endpoint on backend to generate or fallback to random RPG classes
- create a Classes page to manage and select classes
- integrate Classes page into router and navigation
- extend default stats with `class` property and display in stats
- show class in game `stats` command

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68460a174e2083339c8dedbe7ad54989