### PR TITLE
Add AI perk system

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -185,4 +185,33 @@ app.post('/item', async (req, res) => {
   }
 });
 
+app.post('/perk', async (req, res) => {
+  const { seed } = req.body || {};
+  const base =
+    'Generate a RPG perk in the format "NAME: <name>; DESCRIPTION: <description>; STAT: <stat>; TYPE: <percentage|number>; VALUE: <value>".';
+  const prompt = seed ? `${base} Seed: ${seed}` : base;
+  try {
+    const j = await callAI(prompt);
+    const text = j[0]?.generated_text || '';
+    const match = text.match(/NAME:\s*(.*);\s*DESCRIPTION:\s*([^;]+);\s*STAT:\s*(.*?);\s*TYPE:\s*(percentage|number);\s*VALUE:\s*(\d+)/i);
+    if (match) {
+      return res.json({
+        name: match[1].trim(),
+        description: match[2].trim(),
+        stat: match[3].trim().toLowerCase(),
+        type: match[4].trim().toLowerCase(),
+        value: parseInt(match[5], 10)
+      });
+    }
+    throw new Error('parse');
+  } catch {
+    const perks = [
+      { name: 'Tough Skin', description: 'Increase health by 5', stat: 'health', type: 'number', value: 5 },
+      { name: 'Swift', description: 'Increase speed by 10%', stat: 'speed', type: 'percentage', value: 10 },
+      { name: 'Shadow Walker', description: 'Increase stealth by 1', stat: 'stealth', type: 'number', value: 1 }
+    ];
+    res.json(perks[Math.floor(Math.random() * perks.length)]);
+  }
+});
+
 app.listen(PORT, () => console.log(`Backend running on ${PORT}`));

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import User from './Pages/UserPage/User.jsx';
 import Stats from './Pages/StatPage/Stats.jsx';
 import Game from './Pages/GamePage/Game.jsx';
 import Classes from './Pages/ClassPage/Classes.jsx';
+import Perks from './Pages/PerkPage/Perks.jsx';
 
 function App() {
   return (
@@ -21,6 +22,7 @@ function App() {
           <Route path="/User" element={<User/>}/>
           <Route path="/Stats" element={<Stats/>}/>
           <Route path="/Classes" element={<Classes/>}/>
+          <Route path="/Perks" element={<Perks/>}/>
           <Route path="/Game" element={<Game/>}/>
         </Routes>
       </BrowserRouter>

--- a/src/Pages/ClassPage/Classes.jsx
+++ b/src/Pages/ClassPage/Classes.jsx
@@ -1,17 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Paper, TextInput, Textarea, Button, Stack, Title, List, Text } from '@mantine/core';
-
-const defaultStats = {
-  health: 100,
-  level: 1,
-  xp: 0,
-  items: [],
-  skills: [],
-  abilities: [],
-  places: [],
-  people: [],
-  class: '',
-};
+import defaultStats from '../../defaultStats';
 
 const defaultClass = { name: '', description: '' };
 

--- a/src/Pages/GamePage/Game.jsx
+++ b/src/Pages/GamePage/Game.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { TextInput, Button, Stack, Paper, Text } from '@mantine/core';
+import defaultStats from '../../defaultStats';
 
 const directions = {
   north: { x: 0, y: 1 },
@@ -17,17 +18,6 @@ function generateLocation(x, y) {
   return { name, description };
 }
 
-const defaultStats = {
-  health: 100,
-  level: 1,
-  xp: 0,
-  items: [],
-  skills: [],
-  abilities: [],
-  places: [],
-  people: [],
-  class: '',
-};
 
 const Game = () => {
   const [position, setPosition] = useState({ x: 0, y: 0 });
@@ -38,7 +28,7 @@ const Game = () => {
     const saved = localStorage.getItem('playerStats');
     if (saved) {
       try {
-        return JSON.parse(saved);
+        return { ...defaultStats, ...JSON.parse(saved) };
       } catch {
         /* ignore */
       }
@@ -62,7 +52,7 @@ const Game = () => {
     const savedStats = localStorage.getItem('playerStats');
     if (savedStats) {
       try {
-        setStats(JSON.parse(savedStats));
+        setStats({ ...defaultStats, ...JSON.parse(savedStats) });
       } catch {
         /* ignore */
       }
@@ -149,7 +139,7 @@ const Game = () => {
           if (data.places) setPlaces(data.places);
           const savedStats = localStorage.getItem('playerStats');
           if (savedStats) {
-            try { setStats(JSON.parse(savedStats)); } catch {}
+            try { setStats({ ...defaultStats, ...JSON.parse(savedStats) }); } catch {}
           }
           addLog('Game loaded.');
         } catch (e) {

--- a/src/Pages/Navigation/Navigation.jsx
+++ b/src/Pages/Navigation/Navigation.jsx
@@ -28,6 +28,9 @@ const Navigation = () => {
                   <Button component={Link} to="/Classes" variant="gradient" compact gradient={{ from: 'orange', to: 'red', deg: 85 }}>
                     Classes
                   </Button>
+                  <Button component={Link} to="/Perks" variant="gradient" compact gradient={{ from: 'red', to: 'orange', deg: 95 }}>
+                    Perks
+                  </Button>
                   <Button component={Link} to="/Game" variant="gradient" compact gradient={{ from: 'orange', to: 'red', deg: 90 }}>
                     Game
                   </Button>

--- a/src/Pages/PerkPage/Perks.jsx
+++ b/src/Pages/PerkPage/Perks.jsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react';
+import { Paper, Button, Title, Text, Stack } from '@mantine/core';
+import defaultStats from '../../defaultStats';
+
+const Perks = () => {
+  const [stats, setStats] = useState(defaultStats);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('playerStats');
+    if (saved) {
+      try { setStats(JSON.parse(saved)); } catch {}
+    }
+  }, []);
+
+  const saveStats = (s) => {
+    setStats(s);
+    localStorage.setItem('playerStats', JSON.stringify(s));
+  };
+
+  const addPerk = () => {
+    fetch('/perk', { method: 'POST', headers: { 'Content-Type': 'application/json' } })
+      .then(r => r.ok ? r.json() : Promise.reject())
+      .then(p => {
+        const perks = stats.perks || [];
+        saveStats({ ...stats, perks: [...perks, { ...p, level: 0 }] });
+      })
+      .catch(() => {});
+  };
+
+  const levelUp = (idx) => {
+    if (stats.perkPoints <= 0) return;
+    const perks = [...(stats.perks || [])];
+    const perk = { ...perks[idx] };
+    perk.level += 1;
+    const newStats = { ...stats, perkPoints: stats.perkPoints - 1 };
+    if (perk.type === 'percentage') {
+      const current = newStats[perk.stat] || 0;
+      newStats[perk.stat] = current * (1 + perk.value / 100);
+    } else {
+      const current = newStats[perk.stat] || 0;
+      newStats[perk.stat] = current + perk.value;
+    }
+    perks[idx] = perk;
+    newStats.perks = perks;
+    saveStats(newStats);
+  };
+
+  return (
+    <Paper p="md" m="md" shadow="xs">
+      <Title order={2}>Perks</Title>
+      <Text mb="sm">Available Perk Points: {stats.perkPoints}</Text>
+      <Button onClick={addPerk} mb="sm">Generate New Perk</Button>
+      <Stack>
+        {(stats.perks || []).map((p, idx) => (
+          <Paper key={idx} p="sm" shadow="xs">
+            <Title order={4}>{p.name} (Lv {p.level})</Title>
+            <Text>{p.description}</Text>
+            <Button mt="xs" disabled={stats.perkPoints <= 0} onClick={() => levelUp(idx)}>
+              Level Up
+            </Button>
+          </Paper>
+        ))}
+      </Stack>
+    </Paper>
+  );
+};
+
+export default Perks;

--- a/src/Pages/StatPage/Stats.jsx
+++ b/src/Pages/StatPage/Stats.jsx
@@ -1,17 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Paper, Title, Text, List, Button } from '@mantine/core';
-
-const defaultStats = {
-  health: 100,
-  level: 1,
-  xp: 0,
-  items: [],
-  skills: [],
-  abilities: [],
-  places: [],
-  people: [],
-  class: '',
-};
+import defaultStats from '../../defaultStats';
 
 const Stats = () => {
   const [stats, setStats] = useState(defaultStats);
@@ -20,7 +9,7 @@ const Stats = () => {
     const saved = localStorage.getItem('playerStats');
     if (saved) {
       try {
-        setStats(JSON.parse(saved));
+        setStats({ ...defaultStats, ...JSON.parse(saved) });
       } catch {
         /* ignore */
       }
@@ -31,7 +20,7 @@ const Stats = () => {
       fetch(`/save/${id}`)
         .then((r) => r.json())
         .then((d) => {
-          if (d.stats) setStats(d.stats);
+          if (d.stats) setStats({ ...defaultStats, ...d.stats });
         })
         .catch(() => {});
     }
@@ -54,8 +43,14 @@ const Stats = () => {
     <Paper p="md" m="md" shadow="xs">
       <Title order={2}>Player Stats</Title>
       <Text>Health: {stats.health}</Text>
+      <Text>Speed: {stats.speed}</Text>
+      <Text>Stealth: {stats.stealth}</Text>
+      <Text>Strength: {stats.strength}</Text>
+      <Text>Intelligence: {stats.intelligence}</Text>
+      <Text>Music: {stats.music}</Text>
       <Text>Level: {stats.level}</Text>
       <Text>XP: {stats.xp}</Text>
+      <Text>Perk Points: {stats.perkPoints}</Text>
       <Text>Class: {stats.class || 'None'}</Text>
       <Title order={3} mt="sm">Items</Title>
       <List size="sm" withPadding>
@@ -63,6 +58,16 @@ const Stats = () => {
           <List.Item key={idx}>{it}</List.Item>
         ))}
       </List>
+      {stats.perks && stats.perks.length > 0 && (
+        <>
+          <Title order={3} mt="sm">Perks</Title>
+          <List size="sm" withPadding>
+            {stats.perks.map((p, idx) => (
+              <List.Item key={idx}>{p.name} (Lv {p.level})</List.Item>
+            ))}
+          </List>
+        </>
+      )}
       <Title order={3} mt="sm">Visited Locations</Title>
       <List size="sm" withPadding>
         {stats.places.map((pl, idx) => (

--- a/src/defaultStats.js
+++ b/src/defaultStats.js
@@ -1,0 +1,18 @@
+export default {
+  health: 100,
+  speed: 1,
+  stealth: 1,
+  strength: 1,
+  intelligence: 1,
+  music: 1,
+  level: 1,
+  xp: 0,
+  perkPoints: 0,
+  items: [],
+  skills: [],
+  abilities: [],
+  perks: [],
+  places: [],
+  people: [],
+  class: '',
+};


### PR DESCRIPTION
## Summary
- create shared `defaultStats` with perks, perk points, and new stats
- add a new Perks page for leveling perks
- display new stats and perk list in Stats page
- link to Perks in navigation and router
- generate perks via new backend `/perk` endpoint
- merge saved stats with defaults when loading

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68460c29c7fc8333a3ca326d5ded2edd