### PR TITLE
Improve UI/UX across pages

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/Pages/GamePage/StatsCard.jsx
+++ b/src/Pages/GamePage/StatsCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Paper, Title, Text, List } from '@mantine/core';
+import { Paper, Title, Text, List, SimpleGrid } from '@mantine/core';
 
 const STAT_INFO = {
   health: { label: 'Health' },
@@ -58,11 +58,13 @@ const orderedStats = [
 const StatsCard = ({ stats }) => (
   <Paper p="sm" shadow="xs" style={{ maxHeight: '90vh', overflowY: 'auto' }}>
     <Title order={3}>Player Stats</Title>
-    {orderedStats.map((key) => (
-      <Text key={key} size="sm">
-        {STAT_INFO[key].label}: {stats[key] || (key === 'class' ? 'None' : 0)}
-      </Text>
-    ))}
+    <SimpleGrid cols={2} spacing="xs">
+      {orderedStats.map((key) => (
+        <Text key={key} size="sm">
+          {STAT_INFO[key].label}: {stats[key] || (key === 'class' ? 'None' : 0)}
+        </Text>
+      ))}
+    </SimpleGrid>
 
     {stats.items && stats.items.length > 0 && (
       <>

--- a/src/Pages/Navigation/Navigation.jsx
+++ b/src/Pages/Navigation/Navigation.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 
 const Navigation = () => {
   return (
-    <nav>
+    <nav style={{ position: 'sticky', top: 0, zIndex: 1000 }}>
       <div className="Navigation-wrapper">
         <Container fluid m={0} p={0} bg="rgba(0, 0, 0, .3)">
           <Grid className="Grid-Wrapper" justify="center" m={0} mw="100%" grow gutter="xs">

--- a/src/Pages/StatPage/Stats.jsx
+++ b/src/Pages/StatPage/Stats.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Paper, Title, Text, List, Button, HoverCard } from '@mantine/core';
+import { Paper, Title, Text, List, Button, HoverCard, SimpleGrid } from '@mantine/core';
 import { Carousel } from '@mantine/carousel';
 import { useNavigate } from 'react-router-dom';
 import defaultStats from '../../defaultStats';
@@ -118,18 +118,20 @@ const Stats = () => {
   return (
     <Paper p="md" m="md" shadow="xs">
       <Title order={2}>Player Stats</Title>
-      {orderedStats.map((key) => (
-        <HoverCard key={key} width={260} shadow="md" withinPortal>
-          <HoverCard.Target>
-            <Text>
-              {STAT_INFO[key].label}: {stats[key] || (key === 'class' ? 'None' : 0)}
-            </Text>
-          </HoverCard.Target>
-          <HoverCard.Dropdown>
-            <Text size="sm">{STAT_INFO[key].desc}</Text>
-          </HoverCard.Dropdown>
-        </HoverCard>
-      ))}
+      <SimpleGrid cols={2} spacing="xs">
+        {orderedStats.map((key) => (
+          <HoverCard key={key} width={260} shadow="md" withinPortal>
+            <HoverCard.Target>
+              <Text>
+                {STAT_INFO[key].label}: {stats[key] || (key === 'class' ? 'None' : 0)}
+              </Text>
+            </HoverCard.Target>
+            <HoverCard.Dropdown>
+              <Text size="sm">{STAT_INFO[key].desc}</Text>
+            </HoverCard.Dropdown>
+          </HoverCard>
+        ))}
+      </SimpleGrid>
       <Title order={3} mt="sm">Items</Title>
       <List size="sm" withPadding>
         {stats.items.map((it, idx) => (

--- a/src/Styles/Core/PageStylings.scss
+++ b/src/Styles/Core/PageStylings.scss
@@ -2,9 +2,10 @@ html,body {
     margin: 0;
     padding: 0;
 
-    font-family: sans-serif;
-    background: #1a1b1e;
-    color: #fff;
+    font-family: 'Roboto', sans-serif;
+    background: $background-gradient;
+    color: $text-light;
+    min-height: 100vh;
 }
 
 .App {

--- a/src/Styles/variables.scss
+++ b/src/Styles/variables.scss
@@ -1,1 +1,3 @@
 $primary-gradient: linear-gradient(45deg, #ff6b6b, #ffa94d);
+$background-gradient: radial-gradient(circle at top left, #2b2d31, #1a1b1e);
+$text-light: #f8f9fa;

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,9 @@ root.render(
         withGlobalStyles
         withNormalizeCSS
         theme={{
-          colorScheme:"dark",
+          colorScheme: 'dark',
+          fontFamily: 'Roboto, sans-serif',
+          primaryColor: 'orange',
         }}>
         <App />
       </MantineProvider>


### PR DESCRIPTION
## Summary
- make navigation bar sticky at the top
- add Roboto font and theme tweaks
- update global styles and SCSS variables
- display stats using a grid layout

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68470ce9f2948333b57dc46af94a0d40