### PR TITLE
Add responsive layout

### DIFF
--- a/src/Pages/GamePage/Game.jsx
+++ b/src/Pages/GamePage/Game.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { TextInput, Button, Stack, Paper, Text, Flex } from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
 import StatsCard from './StatsCard';
 import defaultStats from '../../defaultStats';
 
@@ -58,6 +59,7 @@ const Game = () => {
   const [places, setPlaces] = useState({});
   const inputRef = useRef(null);
   const logRef = useRef(null);
+  const isMobile = useMediaQuery('(max-width: 768px)');
   const [stats, setStats] = useState(() => {
     const saved = localStorage.getItem('gameSave');
     if (saved) {
@@ -372,7 +374,7 @@ const Game = () => {
   }
 
   return (
-    <Flex align="flex-start" gap="md" p="md">
+    <Flex align="flex-start" gap="md" p="md" direction={isMobile ? 'column' : 'row'}>
       <Stack spacing="xs" style={{ flexGrow: 1 }}>
         <Paper shadow="xs" p="md" style={{ height: '300px', overflowY: 'auto' }} ref={logRef}>
           {log.map((entry, idx) => (

--- a/src/Pages/GamePage/StatsCard.jsx
+++ b/src/Pages/GamePage/StatsCard.jsx
@@ -58,7 +58,7 @@ const orderedStats = [
 const StatsCard = ({ stats }) => (
   <Paper p="sm" shadow="xs" style={{ maxHeight: '90vh', overflowY: 'auto' }}>
     <Title order={3}>Player Stats</Title>
-    <SimpleGrid cols={2} spacing="xs">
+    <SimpleGrid cols={2} spacing="xs" breakpoints={[{ maxWidth: 'sm', cols: 1 }]}>
       {orderedStats.map((key) => (
         <Text key={key} size="sm">
           {STAT_INFO[key].label}: {stats[key] || (key === 'class' ? 'None' : 0)}

--- a/src/Pages/Navigation/Navigation.jsx
+++ b/src/Pages/Navigation/Navigation.jsx
@@ -1,51 +1,37 @@
 import React from 'react';
-import { Container, Grid, Button, Flex } from '@mantine/core';
+import { Container, Button, Flex } from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
 import { Link } from 'react-router-dom';
 
 const Navigation = () => {
+  const isMobile = useMediaQuery('(max-width: 768px)');
   return (
     <nav style={{ position: 'sticky', top: 0, zIndex: 1000 }}>
       <div className="Navigation-wrapper">
         <Container fluid m={0} p={0} bg="rgba(0, 0, 0, .3)">
-          <Grid className="Grid-Wrapper" justify="center" m={0} mw="100%" grow gutter="xs">
-            <Grid.Col span="auto" m={0} mr={10}>
-              <div className="Left-Column-Navigation">
-                <Button component={Link} to="/Authentication" variant="gradient" compact gradient={{ from: 'red', to: 'orange', deg: 60 }}>
-                  Log-In
-                </Button>
-              </div>
-            </Grid.Col>
-
-            <Grid.Col span="auto" align="center" m={0}>
-              <div className="Middle-Column-Navigation">
-                <Flex mih="auto" m={0} gap="xs" justify="flex-start" align="flex-start" direction="row">
-                  <Button component={Link} to="/User" variant="gradient" compact gradient={{ from: 'orange', to: 'red', deg: 70 }}>
-                    User
-                  </Button>
-                  <Button component={Link} to="/Stats" variant="gradient" compact gradient={{ from: 'red', to: 'orange', deg: 80 }}>
-                    Stats
-                  </Button>
-                  <Button component={Link} to="/Classes" variant="gradient" compact gradient={{ from: 'orange', to: 'red', deg: 85 }}>
-                    Classes
-                  </Button>
-                  <Button component={Link} to="/Perks" variant="gradient" compact gradient={{ from: 'red', to: 'orange', deg: 95 }}>
-                    Perks
-                  </Button>
-                  <Button component={Link} to="/Game" variant="gradient" compact gradient={{ from: 'orange', to: 'red', deg: 90 }}>
-                    Game
-                  </Button>
-                </Flex>
-              </div>
-            </Grid.Col>
-
-            <Grid.Col span="auto" offset={4} m={0} ml={10}>
-              <div className="Right-Column-Navigation">
-                <Button component={Link} to="/" variant="gradient" compact gradient={{ from: 'red', to: 'orange', deg: 100 }}>
-                  Home
-                </Button>
-              </div>
-            </Grid.Col>
-          </Grid>
+          <Flex wrap="wrap" justify="center" align="center" gap="xs" p="xs" direction={isMobile ? 'column' : 'row'}>
+            <Button component={Link} to="/Authentication" variant="gradient" compact gradient={{ from: 'red', to: 'orange', deg: 60 }}>
+              Log-In
+            </Button>
+            <Button component={Link} to="/User" variant="gradient" compact gradient={{ from: 'orange', to: 'red', deg: 70 }}>
+              User
+            </Button>
+            <Button component={Link} to="/Stats" variant="gradient" compact gradient={{ from: 'red', to: 'orange', deg: 80 }}>
+              Stats
+            </Button>
+            <Button component={Link} to="/Classes" variant="gradient" compact gradient={{ from: 'orange', to: 'red', deg: 85 }}>
+              Classes
+            </Button>
+            <Button component={Link} to="/Perks" variant="gradient" compact gradient={{ from: 'red', to: 'orange', deg: 95 }}>
+              Perks
+            </Button>
+            <Button component={Link} to="/Game" variant="gradient" compact gradient={{ from: 'orange', to: 'red', deg: 90 }}>
+              Game
+            </Button>
+            <Button component={Link} to="/" variant="gradient" compact gradient={{ from: 'red', to: 'orange', deg: 100 }}>
+              Home
+            </Button>
+          </Flex>
         </Container>
       </div>
     </nav>

--- a/src/Pages/StatPage/Stats.jsx
+++ b/src/Pages/StatPage/Stats.jsx
@@ -118,7 +118,7 @@ const Stats = () => {
   return (
     <Paper p="md" m="md" shadow="xs">
       <Title order={2}>Player Stats</Title>
-      <SimpleGrid cols={2} spacing="xs">
+      <SimpleGrid cols={2} spacing="xs" breakpoints={[{ maxWidth: 'sm', cols: 1 }]}>
         {orderedStats.map((key) => (
           <HoverCard key={key} width={260} shadow="md" withinPortal>
             <HoverCard.Target>

--- a/src/Styles/Core/PageStylings.scss
+++ b/src/Styles/Core/PageStylings.scss
@@ -1,15 +1,22 @@
-html,body {
+
+html, body {
     margin: 0;
     padding: 0;
-
     font-family: 'Roboto', sans-serif;
     background: $background-gradient;
     color: $text-light;
     min-height: 100vh;
+    font-size: clamp(14px, 2.5vw, 16px);
 }
 
 .App {
     min-height: 100vh;
     display: flex;
     flex-direction: column;
+}
+
+@media (max-width: 768px) {
+    .App {
+        padding-bottom: env(safe-area-inset-bottom);
+    }
 }


### PR DESCRIPTION
## Summary
- add CSS clamp sizing and mobile padding
- simplify navigation layout and adapt to screen size
- switch game layout to column on mobile
- update stat grids to single column on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68470f4a7f1c8333bd1b668d4793d41d