### PR TITLE
Add world time tracking system

### DIFF
--- a/src/Pages/GamePage/Game.jsx
+++ b/src/Pages/GamePage/Game.jsx
@@ -3,6 +3,7 @@ import { TextInput, Button, Stack, Paper, Text, Flex } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
 import StatsCard from './StatsCard';
 import defaultStats from '../../defaultStats';
+import { months } from '../../time';
 
 const directions = {
   north: { x: 0, y: 1 },
@@ -171,6 +172,27 @@ const Game = () => {
     };
   }
 
+  function incrementGameTime(hours = 1) {
+    setStats((prev) => {
+      const wt = { ...prev.worldTime };
+      wt.survivalHours += hours;
+      wt.hour += hours;
+      while (wt.hour >= 24) {
+        wt.hour -= 24;
+        wt.day += 1;
+      }
+      while (wt.day > 30) {
+        wt.day -= 30;
+        wt.month += 1;
+      }
+      while (wt.month >= months.length) {
+        wt.month -= months.length;
+        wt.year += 1;
+      }
+      return { ...prev, worldTime: wt };
+    });
+  }
+
   function saveGame() {
     const state = getState();
     localStorage.setItem('gameSave', JSON.stringify(state));
@@ -220,6 +242,9 @@ const Game = () => {
 
   function updateStats(patch) {
     const newStats = { ...stats, ...patch };
+    if (patch.worldTime) {
+      newStats.worldTime = { ...stats.worldTime, ...patch.worldTime };
+    }
     setStats(newStats);
     localStorage.setItem('playerStats', JSON.stringify(newStats));
   }
@@ -370,6 +395,7 @@ const Game = () => {
       addLog('Unknown command.');
     }
 
+    incrementGameTime(1);
     inputRef.current?.focus();
   }
 

--- a/src/Pages/GamePage/StatsCard.jsx
+++ b/src/Pages/GamePage/StatsCard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Paper, Title, Text, List, SimpleGrid } from '@mantine/core';
+import { months, formatHour } from '../../time';
 
 const STAT_INFO = {
   health: { label: 'Health' },
@@ -119,6 +120,21 @@ const StatsCard = ({ stats }) => (
             const ability = typeof ab === 'string' ? { name: ab } : ab;
             return <List.Item key={idx}>{ability.name}</List.Item>;
           })}
+        </List>
+      </>
+    )}
+
+    {stats.worldTime && (
+      <>
+        <Title order={4} mt="sm">World Time</Title>
+        <List size="sm" withPadding>
+          <List.Item>Year: {stats.worldTime.year}</List.Item>
+          <List.Item>Month: {months[stats.worldTime.month]}</List.Item>
+          <List.Item>Day: {stats.worldTime.day}</List.Item>
+          <List.Item>Time: {formatHour(stats.worldTime.hour)}</List.Item>
+          <List.Item>
+            Survival Length: {Math.floor((stats.worldTime.survivalHours || 0)/24)} days { (stats.worldTime.survivalHours || 0)%24 } hours
+          </List.Item>
         </List>
       </>
     )}

--- a/src/Pages/StatPage/Stats.jsx
+++ b/src/Pages/StatPage/Stats.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Paper, Title, Text, List, Button, HoverCard, SimpleGrid } from '@mantine/core';
+import { months, formatHour } from '../../time';
 import { Carousel } from '@mantine/carousel';
 import { useNavigate } from 'react-router-dom';
 import defaultStats from '../../defaultStats';
@@ -184,6 +185,20 @@ const Stats = () => {
               );
             })}
           </Carousel>
+        </>
+      )}
+      {stats.worldTime && (
+        <>
+          <Title order={3} mt="sm">World Time</Title>
+          <List size="sm" withPadding>
+            <List.Item>Year: {stats.worldTime.year}</List.Item>
+            <List.Item>Month: {months[stats.worldTime.month]}</List.Item>
+            <List.Item>Day: {stats.worldTime.day}</List.Item>
+            <List.Item>Time: {formatHour(stats.worldTime.hour)}</List.Item>
+            <List.Item>
+              Survival Length: {Math.floor((stats.worldTime.survivalHours || 0)/24)} days { (stats.worldTime.survivalHours || 0)%24 } hours
+            </List.Item>
+          </List>
         </>
       )}
       <Button mt="md" onClick={handleSave}>Save Stats</Button>

--- a/src/defaultStats.js
+++ b/src/defaultStats.js
@@ -43,4 +43,11 @@ export default {
   places: [],
   people: [],
   class: '',
+  worldTime: {
+    year: 110,
+    month: 0,
+    day: 1,
+    hour: 0,
+    survivalHours: 0,
+  },
 };

--- a/src/time.js
+++ b/src/time.js
@@ -1,0 +1,17 @@
+export const months = [
+  'Zephyr', 'Blossom', 'Cinder', 'Dusk', 'Ember',
+  'Frost', 'Gale', 'Hearth', 'Ivory', 'Jade',
+  'Kismet', 'Lumen', 'Morrow', 'Nexus', 'Omen',
+  'Pyre', 'Quell', 'Riven', 'Solace', 'Thorn',
+  'Umbra', 'Vale', 'Whisper', 'Xenith', 'Yield'
+];
+
+export function formatHour(hour, use12=false) {
+  if (use12) {
+    const h = ((hour % 12) || 12);
+    const ampm = hour < 12 ? 'AM' : 'PM';
+    return `${h}:00 ${ampm}`;
+  }
+  const h = hour.toString().padStart(2, '0');
+  return `${h}:00`;
+}


### PR DESCRIPTION
## Summary
- implement world time helpers in `time.js`
- add default `worldTime` entry in character stats
- display world time in StatsCard and Stats page
- track passage of time in the Game component

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68471368b86083339ff8b5b7aebc0b21