### PR TITLE
Implement buff/debuff system

### DIFF
--- a/src/Pages/GamePage/StatsCard.jsx
+++ b/src/Pages/GamePage/StatsCard.jsx
@@ -131,6 +131,28 @@ const StatsCard = ({ stats }) => (
       </>
     )}
 
+    {stats.buffs && stats.buffs.length > 0 && (
+      <>
+        <Title order={4} mt="sm">Buffs</Title>
+        <List size="sm" withPadding>
+          {stats.buffs.map((b, idx) => (
+            <List.Item key={idx}>{b.name} x{b.stacks} ({b.duration}h)</List.Item>
+          ))}
+        </List>
+      </>
+    )}
+
+    {stats.statusEffects && stats.statusEffects.length > 0 && (
+      <>
+        <Title order={4} mt="sm">Status Effects</Title>
+        <List size="sm" withPadding>
+          {stats.statusEffects.map((s, idx) => (
+            <List.Item key={idx}>{s.name} ({s.duration}h)</List.Item>
+          ))}
+        </List>
+      </>
+    )}
+
     {stats.worldTime && (
       <>
         <Title order={4} mt="sm">World Time</Title>

--- a/src/defaultStats.js
+++ b/src/defaultStats.js
@@ -44,6 +44,8 @@ export default {
   places: [],
   people: [],
   class: '',
+  buffs: [],
+  statusEffects: [],
   worldTime: {
     year: 110,
     month: 0,


### PR DESCRIPTION
## Summary
- support buffs, debuffs, and status effects
- update StatsCard to show active effects
- store buffs in saved stats

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68471929fa7c83339ddeb30647e3a7e0